### PR TITLE
feat: update models to an exact number and using o4-mini instead of 4o!

### DIFF
--- a/tasks/hivemind/agent.py
+++ b/tasks/hivemind/agent.py
@@ -20,7 +20,7 @@ class AgenticFlowState(BaseModel):
 
 
 class AgenticHivemindFlow(Flow[AgenticFlowState]):
-    model = "gpt-4o"
+    model = "o4-mini-2025-04-16"
 
     def __init__(
         self,
@@ -105,7 +105,7 @@ class AgenticHivemindFlow(Flow[AgenticFlowState]):
                 "You are an intelligent agent capable of giving concise answers to questions."
             ),
             allow_delegation=True,
-            llm=LLM(model="gpt-4o-mini"),
+            llm=LLM(model="gpt-4o-mini-2024-07-18"),
         )
         rag_task = Task(
             description=(
@@ -124,7 +124,7 @@ class AgenticHivemindFlow(Flow[AgenticFlowState]):
             agents=[q_a_bot_agent],
             tasks=[rag_task],
             process=Process.hierarchical,
-            manager_llm=LLM(model="gpt-4o-mini"),
+            manager_llm=LLM(model="gpt-4o-mini-2024-07-18"),
             verbose=True,
         )
 
@@ -146,7 +146,7 @@ class AgenticHivemindFlow(Flow[AgenticFlowState]):
             backstory=(
                 "You are an intelligent agent capable of giving concise answers to questions."
             ),
-            llm=LLM(model="gpt-4o-mini"),
+            llm=LLM(model="gpt-4o-mini-2024-07-18"),
         )
 
         @tool

--- a/tasks/hivemind/classify_question.py
+++ b/tasks/hivemind/classify_question.py
@@ -6,7 +6,7 @@ from transformers import pipeline
 
 
 class ClassifyQuestion:
-    def __init__(self, model: str = "gpt-4o-mini"):
+    def __init__(self, model: str = "gpt-4o-mini-2024-07-18"):
         load_dotenv()
         self.model = model
         self.api_key = os.getenv("OPENAI_API_KEY")

--- a/tests/unit/test_check_question.py
+++ b/tests/unit/test_check_question.py
@@ -6,7 +6,7 @@ from tasks.hivemind.classify_question import ClassifyQuestion
 
 class TestClassifyQuestion(unittest.TestCase):
     def setUp(self):
-        self.model = "gpt-4o-mini"
+        self.model = "gpt-4o-mini-2024-07-18"
         self.check_question = ClassifyQuestion(self.model)
 
     @patch("transformers.pipeline")


### PR DESCRIPTION
Reason:
+ Added an exact version of gpt4o-mini, so in future if it was updated our bot's behavior won't change.
+ Also, o4-mini is cheaper than 4o